### PR TITLE
Add outline of services

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,31 @@
 parameters:
-	ignoreErrors: []
+	ignoreErrors:
+		-
+			message: "#^Property ProfessionalWiki\\\\WikibaseExport\\\\Application\\\\Export\\\\EntityMapper\\:\\:\\$endTime is never read, only written\\.$#"
+			count: 1
+			path: src/Application/Export/EntityMapper.php
+
+		-
+			message: "#^Property ProfessionalWiki\\\\WikibaseExport\\\\Application\\\\Export\\\\EntityMapper\\:\\:\\$startTime is never read, only written\\.$#"
+			count: 1
+			path: src/Application/Export/EntityMapper.php
+
+		-
+			message: "#^Property ProfessionalWiki\\\\WikibaseExport\\\\Application\\\\Export\\\\EntityMapper\\:\\:\\$statementPropertyIds is never read, only written\\.$#"
+			count: 1
+			path: src/Application/Export/EntityMapper.php
+
+		-
+			message: "#^Parameter \\$endTime of class ProfessionalWiki\\\\WikibaseExport\\\\Application\\\\Export\\\\EntityMapper constructor expects DateTimeImmutable, DateTimeImmutable\\|null given\\.$#"
+			count: 1
+			path: src/Application/Export/ExportUseCase.php
+
+		-
+			message: "#^Parameter \\$startTime of class ProfessionalWiki\\\\WikibaseExport\\\\Application\\\\Export\\\\EntityMapper constructor expects DateTimeImmutable, DateTimeImmutable\\|null given\\.$#"
+			count: 1
+			path: src/Application/Export/ExportUseCase.php
+
+		-
+			message: "#^Parameter \\$statementPropertyIds of class ProfessionalWiki\\\\WikibaseExport\\\\Application\\\\Export\\\\EntityMapper constructor expects array\\<int, Wikibase\\\\DataModel\\\\Entity\\\\PropertyId\\>, array\\<int, string\\> given\\.$#"
+			count: 1
+			path: src/Application/Export/ExportUseCase.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,2 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.7.2@83a0325c0a95c0ab531d6b90c877068b464377b5"/>
+<files psalm-version="4.7.2@83a0325c0a95c0ab531d6b90c877068b464377b5">
+  <file src="src/Application/Export/ExportUseCase.php">
+    <InvalidArgument occurrences="1">
+      <code>$exportRequest-&gt;statementPropertyIds</code>
+    </InvalidArgument>
+    <PossiblyNullArgument occurrences="2">
+      <code>$exportRequest-&gt;endTime</code>
+      <code>$exportRequest-&gt;startTime</code>
+    </PossiblyNullArgument>
+  </file>
+</files>

--- a/src/Application/EntitySource.php
+++ b/src/Application/EntitySource.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application;
+
+use Wikibase\DataModel\Entity\EntityDocument;
+
+interface EntitySource {
+
+	public function next(): ?EntityDocument;
+
+}

--- a/src/Application/Export/EntityMapper.php
+++ b/src/Application/Export/EntityMapper.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application\Export;
+
+use DateTimeImmutable;
+use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\PropertyId;
+
+class EntityMapper {
+
+	/**
+	 * @param array<int, PropertyId> $statementPropertyIds
+	 */
+	public function __construct(
+		private array $statementPropertyIds,
+		private DateTimeImmutable $startTime,
+		private DateTimeImmutable $endTime,
+	) {
+	}
+
+	public function map( EntityDocument $entity ): MappedEntity {
+		return new MappedEntity(); // TODO
+	}
+
+}

--- a/src/Application/Export/ExportPresenter.php
+++ b/src/Application/Export/ExportPresenter.php
@@ -1,0 +1,11 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application\Export;
+
+interface ExportPresenter {
+
+	public function present( ExportResponse $response ): void;
+
+}

--- a/src/Application/Export/ExportRequest.php
+++ b/src/Application/Export/ExportRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application\Export;
+
+use DateTimeImmutable;
+
+class ExportRequest {
+
+	/**
+	 * @param array<int, string> $subjectIds
+	 * @param array<int, string> $statementPropertyIds
+	 */
+	public function __construct(
+		// TODO: stings or objects?
+		// TODO: include subject IDs?
+		public array $subjectIds,
+		public array $statementPropertyIds,
+		public ?DateTimeImmutable $startTime,
+		public ?DateTimeImmutable $endTime,
+	) {
+	}
+
+}

--- a/src/Application/Export/ExportResponse.php
+++ b/src/Application/Export/ExportResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application\Export;
+
+class ExportResponse {
+
+	public function add( MappedEntity $map ): void {
+		// TODO
+	}
+
+}

--- a/src/Application/Export/ExportUseCase.php
+++ b/src/Application/Export/ExportUseCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application\Export;
+
+use ProfessionalWiki\WikibaseExport\Application\EntitySource;
+
+class ExportUseCase {
+
+	public function __construct(
+		private ExportPresenter $presenter,
+		private EntitySource $entitySource,
+	) {
+	}
+
+	public function export( ExportRequest $exportRequest ): void {
+		// TODO: auth
+
+		$this->presenter->present( $this->buildResponse( $this->newEntityMapper( $exportRequest ) ) );
+	}
+
+	private function buildResponse( EntityMapper $mapper ): ExportResponse {
+		$response = new ExportResponse();
+
+		while ( true ) {
+			$entity = $this->entitySource->next();
+
+			if ( $entity === null ) {
+				break;
+			}
+
+			$response->add( $mapper->map( $entity ) );
+		}
+
+		return $response;
+	}
+
+	private function newEntityMapper( ExportRequest $exportRequest ): EntityMapper {
+		return new EntityMapper(
+			statementPropertyIds: $exportRequest->statementPropertyIds,
+			startTime: $exportRequest->startTime,
+			endTime: $exportRequest->endTime
+		);
+	}
+
+}

--- a/src/Application/Export/MappedEntity.php
+++ b/src/Application/Export/MappedEntity.php
@@ -1,0 +1,9 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application\Export;
+
+class MappedEntity {
+
+}

--- a/src/Presentation/WideCsvPresenter.php
+++ b/src/Presentation/WideCsvPresenter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Presentation;
+
+use ProfessionalWiki\WikibaseExport\Application\Export\ExportPresenter;
+use ProfessionalWiki\WikibaseExport\Application\Export\ExportResponse;
+
+class WideCsvPresenter implements ExportPresenter {
+
+	public function present( ExportResponse $response ): void {
+		// TODO
+	}
+
+}

--- a/tests/Integration/ExportUseCaseTest.php
+++ b/tests/Integration/ExportUseCaseTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseExport\Application\Export\ExportUseCase
+ */
+class ExportUseCaseTest extends TestCase {
+
+	public function testTodo(): void {
+		$this->assertTrue( true );
+	}
+
+}


### PR DESCRIPTION
The request model is still uncear due to two open questions:
* Do we inject a concrete EntitySource into the UC, or do we build one in the UC based on request model info. Currently the presenter is build outside based on the requested format.
* Do we use EntityId objects in the request model or stings that then still need to be parsed.