### PR TITLE
Add initial entity select widget

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -57,6 +57,19 @@
 	},
 
 	"ResourceModules": {
+		"ext.wikibase.export": {
+			"dependencies": [
+				"oojs-ui-core",
+				"oojs-ui-widgets"
+			],
+			"styles": [
+				"ext.wikibase.export.less"
+			],
+			"scripts": [
+				"mw.widgets.EntitiesMultiselectWidget.js",
+				"ext.wikibase.export.js"
+			]
+		}
 	},
 
 	"ExtensionMessagesFiles": {

--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -1,0 +1,59 @@
+/*
+ * JavaScript for WikibaseExport
+ */
+
+$( function () {
+	'use strict';
+
+	function init() {
+		var wikibaseExport = $( document.getElementById( 'wikibase-export' ) );
+
+		var subjects = new mw.widgets.EntitiesMultiselectWidget( {
+			inputPosition: 'outline',
+			placeholder: 'Search companies',
+			// TODO: get default values somewhere
+			selected: [
+				'Q100', 'Q200'
+			],
+			options: [
+				{ data: 'Q100', label: 'Foo Bar' },
+				{ data: 'Q200', label: 'Bar Baz' },
+			]
+		} );
+
+		var subjectsFieldset = new OO.ui.FieldsetLayout( {
+			label: 'Choose companies'
+		} );
+		subjectsFieldset.addItems( [ subjects ] );
+
+		var subjectsPanel = new OO.ui.PanelLayout( {
+			expanded: false,
+			framed: true,
+			padded: true,
+			$content: subjectsFieldset.$element,
+			classes: [
+				'container'
+			]
+		} );
+		wikibaseExport.append( subjectsPanel.$element );
+
+		var submitButton = new OO.ui.ButtonWidget({
+			label: 'Download',
+			flags: [
+				'primary',
+				'progressive'
+			]
+		} );
+
+		submitButton.on( 'click', function () {
+			const subjectIds = subjects.getValue().join( '|' );
+			// TODO: build the correct URL
+			window.location = '/rest.php/wikibase-export/v0/export?subject_ids=' + subjectIds + '&statement_property_ids=P1|P2&start_time=2021&end_time=2022=format=csvwide';
+		} );
+
+		wikibaseExport.append( submitButton.$element );
+	}
+
+	init();
+
+} );

--- a/resources/ext.wikibase.export.less
+++ b/resources/ext.wikibase.export.less
@@ -1,0 +1,4 @@
+.container {
+	// TODO: is there an OOUI way to use the default width limit?
+	max-width: 50em;
+}

--- a/resources/mw.widgets.EntitiesMultiselectWidget.js
+++ b/resources/mw.widgets.EntitiesMultiselectWidget.js
@@ -1,0 +1,98 @@
+( function () {
+
+	/**
+	 * Creates an mw.widgets.EntitiesMultiselectWidget object
+	 *
+	 * @class
+	 * @extends OO.ui.MenuTagMultiselectWidget
+	 *
+	 * @constructor
+	 * @param {Object} [config] Configuration options
+	 */
+	mw.widgets.EntitiesMultiselectWidget = function MwWidgetsEntitiesMultiselectWidget( config ) {
+		// Parent constructor
+		mw.widgets.EntitiesMultiselectWidget.parent.call( this, $.extend( true,
+			{
+				clearInputOnChoose: false,
+				inputPosition: 'inline',
+				allowEditTags: false
+			},
+			config
+		) );
+
+		// Initialization
+		this.$element
+			.addClass( 'mw-widgets-EntitiesMultiselectWidget' );
+
+		if ( 'name' in config ) {
+			// Use this instead of <input type="hidden">, because hidden inputs do not have separate
+			// 'value' and 'defaultValue' properties.
+			this.$hiddenInput = $( '<textarea>' )
+				.addClass( 'oo-ui-element-hidden' )
+				.attr( 'name', config.name )
+				.appendTo( this.$element );
+			// Update with preset values
+			// Set the default value (it might be different from just being empty)
+			this.$hiddenInput.prop( 'defaultValue', this.getItems().map( function ( item ) {
+				return item.getData();
+			} ).join( '\n' ) );
+			this.on( 'change', function ( items ) {
+				this.$hiddenInput.val( items.map( function ( item ) {
+					return item.getData();
+				} ).join( '\n' ) );
+				// Trigger a 'change' event as if a user edited the text
+				// (it is not triggered when changing the value from JS code).
+				this.$hiddenInput.trigger( 'change' );
+			}.bind( this ) );
+		}
+
+	};
+
+	/* Setup */
+
+	OO.inheritClass( mw.widgets.EntitiesMultiselectWidget, OO.ui.MenuTagMultiselectWidget );
+
+	/* Methods */
+
+	mw.widgets.EntitiesMultiselectWidget.prototype.getQueryValue = function () {
+		return this.input.getValue();
+	};
+
+	/**
+	 * @inheritdoc OO.ui.MenuTagMultiselectWidget
+	 */
+	mw.widgets.EntitiesMultiselectWidget.prototype.onInputChange = function () {
+		var widget = this;
+
+		this.getRequestData()
+			.then( function ( data ) {
+				widget.menu.clearItems();
+				widget.menu.addItems( widget.getOptionsFromData( data ) );
+			} ).always( function() {
+				mw.widgets.EntitiesMultiselectWidget.parent.prototype.onInputChange.call( widget );
+			} );
+	};
+
+	mw.widgets.EntitiesMultiselectWidget.prototype.getRequestData = function () {
+		return new mw.Api().get( {
+			action: 'wbsearchentities',
+			type: 'item',
+			language: 'en',
+			search: this.getQueryValue()
+		} );
+	}
+
+	mw.widgets.EntitiesMultiselectWidget.prototype.getOptionsFromData = function ( data ) {
+		var items = [];
+
+		for ( var i = 0; i < data.search.length; i++ ) {
+			items.push( new OO.ui.MenuOptionWidget( {
+				data: data.search[ i ].id,
+				label: data.search[ i ].label
+			} ) );
+		}
+
+		return items;
+	}
+
+}() );

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -14,7 +14,10 @@ class SpecialWikibaseExport extends SpecialPage {
 
 	public function execute( $subPage ): void {
 		parent::execute( $subPage );
-		$this->getOutput()->addHTML( 'TODO' );
+		$output = $this->getOutput();
+		$output->enableOOUI();
+		$output->addModules( 'ext.wikibase.export' );
+		$output->addHTML( '<div id="wikibase-export"></div>' );
 	}
 
 	public function getGroupName(): string {

--- a/tests/EntryPoints/SpecialWikibaseExportTest.php
+++ b/tests/EntryPoints/SpecialWikibaseExportTest.php
@@ -16,12 +16,12 @@ class SpecialWikibaseExportTest extends SpecialPageTestBase {
 		return new SpecialWikibaseExport();
 	}
 
-	public function testStub(): void {
+	public function testWrapperIsPresent(): void {
 		/** @var string $output */
 		[ $output ] = $this->executeSpecialPage();
 
 		$this->assertStringContainsString(
-			'TODO',
+			'<div id="wikibase-export"></div>',
 			$output
 		);
 	}


### PR DESCRIPTION
Refs #8

Very, very rough initial implementation. Based on a stripped down `MwWidgetsTitlesMultiselectWidget`.

* Provides a place to add defaults
* Uses the `wbsearchentities` API, but is currently uncached
* Need to review what API/request related logic was stripped out and what those things do
* Submits the entity IDs to the export REST API when the button is clicked

On page load:
![Screenshot_20221107_221516](https://user-images.githubusercontent.com/1428594/200406067-861c638d-721c-448b-8b2f-8dc6e82e6ed6.png)

When searching:
![Screenshot_20221107_221534](https://user-images.githubusercontent.com/1428594/200406131-5d42b621-f246-4dfe-b14d-84f5ea6b0713.png)
![Screenshot_20221107_221602](https://user-images.githubusercontent.com/1428594/200406231-6d7020c3-8a47-40ff-bdd1-9e150df03d63.png)

