### PR TITLE
Use number input widget for years

### DIFF
--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -42,13 +42,9 @@ $( function () {
 		wikibaseExport.append( subjectsPanel.$element );
 
 		/* Filters */
-		var dateStart = new OO.ui.TextInputWidget( {
-			validate: 'integer'
-		} );
+		var dateStart = new OO.ui.NumberInputWidget();
 
-		var dateEnd = new OO.ui.TextInputWidget( {
-			validate: 'integer'
-		} );
+		var dateEnd = new OO.ui.NumberInputWidget();
 
 		var filtersFieldset = new OO.ui.FieldsetLayout( {
 			label: 'Choose time range',


### PR DESCRIPTION
Refs https://github.com/ProfessionalWiki/WikibaseExport/pull/23#issuecomment-1307106094

![Screenshot_20221108_142038](https://user-images.githubusercontent.com/1428594/200562220-4865303b-0cdc-4e2c-8b40-92a398baa190.png)

The -+ buttons can be hidden while still retaining the behavior of a plain `<input type="number">`.
