### PR TITLE
Use extension vendor for Psalm and Stan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ phpcs:
 	cd ../.. && vendor/bin/phpcs -p -s --standard=$(shell pwd)/phpcs.xml
 
 stan:
-	../../vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G
+	vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G
 
 stan-baseline:
-	../../vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G --generate-baseline
+	vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G --generate-baseline
 
 psalm:
-	../../vendor/bin/psalm --config=psalm.xml
+	vendor/bin/psalm --config=psalm.xml
 
 psalm-baseline:
-	../../vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
+	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml


### PR DESCRIPTION
This means we have to `composer install` in the extension dir first.

When running the Make command on https://github.com/ProfessionalWiki/WikibaseExport/pull/33 I now also get the same error as the CI run:
![Screenshot_20221111_101114](https://user-images.githubusercontent.com/1428594/201295408-1dfd9c5f-3ce8-467a-bda1-040f820df7c4.png)

----

This isn't strictly necessary for PHPStan, since it is not (currently) held back due to MW pinning a dependency.
