### PR TITLE
Add allowed properties and "all" checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Wikibase Export
+
+## PHP Configuration
+
+Configuration can be changed via [LocalSettings.php].
+
+### Allowed properties
+
+List of allowed property IDs.
+
+Variable: `$wgWikibaseExportProperties`
+
+Default: `[]`
+
+Example:
+
+```php
+$wgWikibaseExportProperties = [
+	'P2',
+	'P3',
+	'P5'
+];
+```

--- a/extension.json
+++ b/extension.json
@@ -45,6 +45,10 @@
 	],
 
 	"config": {
+		"WikibaseExportProperties": {
+			"description": "List of property IDs allowed in the export.",
+			"value": []
+		}
 	},
 
 	"SpecialPages": {
@@ -76,6 +80,7 @@
 				"wikibase-export-start-year",
 				"wikibase-export-end-year",
 				"wikibase-export-statements-heading",
+				"wikibase-export-statement-group-all",
 				"wikibase-export-statements-placeholder",
 				"wikibase-export-formats-heading",
 				"wikibase-export-format-csv-wide",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -15,6 +15,7 @@
 	"wikibase-export-start-year": "Start year",
 	"wikibase-export-end-year": "End year",
 	"wikibase-export-statements-heading": "Choose variables",
+	"wikibase-export-statement-group-all": "All variables",
 	"wikibase-export-statements-placeholder": "Search variables",
 	"wikibase-export-formats-heading": "Choose format",
 	"wikibase-export-format-csv-wide": "CSV (Wide)",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -15,6 +15,7 @@
 	"wikibase-export-start-year": "This is the text used as a label.",
 	"wikibase-export-end-year": "This is the text used as a label.",
 	"wikibase-export-statements-heading": "This is a section header.",
+	"wikibase-export-statement-group-all": "This is the text of an option.",
 	"wikibase-export-statements-placeholder": "This is the text used as a placeholder.",
 	"wikibase-export-formats-heading": "This is a section header.",
 	"wikibase-export-format-csv-wide": "This is the text of an option.",

--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -45,7 +45,7 @@ $( function () {
 		 * @param {string} value
 		 * @param {string} label
 		 * @param {boolean} selected
-		 * @return OO.ui.FieldLayout
+		 * @return {OO.ui.FieldLayout}
 		 */
 		createCheckbox: function ( value, label, selected = false ) {
 			return new OO.ui.FieldLayout(

--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -42,6 +42,25 @@ $( function () {
 		},
 
 		/**
+		 * @param {string} value
+		 * @param {string} label
+		 * @param {boolean} selected
+		 * @return OO.ui.FieldLayout
+		 */
+		createCheckbox: function ( value, label, selected = false ) {
+			return new OO.ui.FieldLayout(
+				new OO.ui.CheckboxInputWidget( {
+					value: value,
+					selected: selected
+				} ),
+				{
+					label: label,
+					align: 'inline'
+				}
+			);
+		},
+
+		/**
 		 * @return {OO.ui.PanelLayout}
 		 */
 		createSubjectsSection: function () {
@@ -96,21 +115,69 @@ $( function () {
 		 * @return {OO.ui.PanelLayout}
 		 */
 		createStatementsSection: function () {
-			this.statements = new mw.widgets.EntitiesMultiselectWidget( {
+			const widget = this;
+
+			const allStatementsLayout = this.createCheckbox( 'all', mw.msg( 'wikibase-export-statement-group-all' ), true );
+			this.allStatements = allStatementsLayout.getField();
+
+			this.statements = new OO.ui.MenuTagMultiselectWidget( {
 				id: 'statements',
 				inputPosition: 'outline',
-				placeholder: mw.msg( 'wikibase-export-statements-placeholder' ),
-				// TODO: get default values somewhere
-				selected: [],
-				options: [],
-				entityType: 'property'
+				placeholder: mw.msg( 'wikibase-export-statements-placeholder' )
 			} );
+			this.statements.toggle( false );
+
+			this.allStatements.on( 'change', function ( selected ) {
+				if ( selected ) {
+					widget.statements.toggle( false );
+					widget.statements.setValue( widget.statements.menu.getItems() );
+				} else {
+					widget.statements.toggle( true );
+				}
+			} );
+
+			this.addAllowedProperties();
 
 			return this.createSection(
 				'statements',
 				mw.msg( 'wikibase-export-statements-heading' ),
-				[ this.statements ]
+				[ allStatementsLayout, this.statements ]
 			);
+		},
+
+		addAllowedProperties: function () {
+			const widget = this;
+
+			new mw.Api().get( {
+				action: 'wbgetentities',
+				ids: mw.config.get( 'wgWikibaseExportProperties' )
+			} ).then( function ( data ) {
+				const options = widget.getPropertyOptionsFromData( data );
+				widget.statements.addOptions( options );
+				widget.statements.setValue( options );
+			} );
+		},
+
+		/**
+		 * @param {Object} data
+		 * @return {{data: *, label: *}[]}
+		 */
+		getPropertyOptionsFromData: function ( data ) {
+			return Object.keys( data.entities ).map(
+				( key ) => this.getPropertyOptionFromEntity( data.entities[ key ] )
+			);
+		},
+
+		/**
+		 * @param {Object} entity
+		 * @return {{data: string, label: string}}
+		 */
+		getPropertyOptionFromEntity: function ( entity ) {
+			return {
+				data: entity.id,
+				// TODO: try current language, then fallback to default
+				label: entity.labels.en.value || entity.id
+			};
 		},
 
 		/**

--- a/resources/ext.wikibase.export.less
+++ b/resources/ext.wikibase.export.less
@@ -2,3 +2,7 @@
 	// TODO: is there an OOUI way to use the default width limit?
 	max-width: 50em;
 }
+
+.oo-ui-menuSelectWidget {
+	max-height: 300px;
+}

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseExport\EntryPoints;
 
+use MediaWiki\MediaWikiServices;
 use SpecialPage;
 
 class SpecialWikibaseExport extends SpecialPage {
@@ -18,6 +19,7 @@ class SpecialWikibaseExport extends SpecialPage {
 		$output->enableOOUI();
 		$output->addModules( 'ext.wikibase.export' );
 		$output->addHTML( '<div id="wikibase-export"></div>' );
+		$output->addJsConfigVars( $this->getJsConfigVars() );
 	}
 
 	public function getGroupName(): string {
@@ -26,6 +28,17 @@ class SpecialWikibaseExport extends SpecialPage {
 
 	public function getDescription(): string {
 		return $this->msg( 'special-wikibase-export' )->escaped();
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function getJsConfigVars(): array {
+		// TODO: create extension config retrieval service
+		$properties = MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseExportProperties' );
+		return [
+			'wgWikibaseExportProperties' => $properties,
+		];
 	}
 
 }

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -35,7 +35,7 @@ class SpecialWikibaseExport extends SpecialPage {
 	 */
 	private function getJsConfigVars(): array {
 		// TODO: create extension config retrieval service
-		$properties = MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseExportProperties' );
+		$properties = (array)MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseExportProperties' );
 		return [
 			'wgWikibaseExportProperties' => $properties,
 		];


### PR DESCRIPTION
Refs #31 

Default
![Screenshot_20221111_113021](https://user-images.githubusercontent.com/1428594/201310265-6177e36f-b6bc-4a5d-bb82-2075092a7390.png)

When deselecting it shows the properties widget:
![Screenshot_20221111_113057](https://user-images.githubusercontent.com/1428594/201310391-5f2dff9c-a5c3-4621-b756-c00c4f67e350.png)

If you deselect properties, and then click 'All' then the properties widget selects all the items internally (while hidden). So when you deselect 'All' again, everything will be pre-selected again. This allows the widget to still be used for maintaining state. I still need to decide if this is a good idea. I can think of two alternatives:
* instead of getting the selected values from the widget, just get it from the config, since we have it anyway
* instead of passing property IDs to the API call, rather use a different variable like "statement_group=all"