### PR TITLE
Clear selected properties on deselecting all

### DIFF
--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -133,9 +133,9 @@ $( function () {
 					widget.statements.setValue( widget.statements.menu.getItems() );
 				} else {
 					// TODO: is there an OOUI way to clear everything?
-					widget.statements.getValue().forEach( function ( statement ) {
-						widget.statements.removeTagByData( statement );
-					} );
+					widget.statements.getValue().forEach(
+						( statement ) => widget.statements.removeTagByData( statement )
+					);
 					widget.statements.toggle( true );
 				}
 			} );

--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -132,6 +132,10 @@ $( function () {
 					widget.statements.toggle( false );
 					widget.statements.setValue( widget.statements.menu.getItems() );
 				} else {
+					// TODO: is there an OOUI way to clear everything?
+					widget.statements.getValue().forEach( function ( statement ) {
+						widget.statements.removeTagByData( statement );
+					} );
 					widget.statements.toggle( true );
 				}
 			} );


### PR DESCRIPTION
Refs https://github.com/ProfessionalWiki/WikibaseExport/pull/35#issuecomment-1311695364

I couldn't immediately find an OOUI method that does the same. There might not actually be a lot of OOUI use cases for clearing everything like this, so maybe I'm not totally missing it.