### PR TITLE
Extract UC building code from API

### DIFF
--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -249,8 +249,8 @@ $( function () {
 			return new URLSearchParams( {
 				subject_ids: subjectIds,
 				statement_property_ids: propertyIds,
-				start_time: startTime,
-				end_time: endTime,
+				start_year: startTime,
+				end_year: endTime,
 				format: format
 			} );
 			/* eslint-enable camelcase */

--- a/src/Application/Export/ExportRequest.php
+++ b/src/Application/Export/ExportRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application\Export;
+
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\PropertyId;
+
+class ExportRequest {
+
+	/**
+	 * @param EntityId[] $subjectIds
+	 * @param PropertyId[] $statementPropertyIds
+	 */
+	public function __construct(
+		public /* readonly */ array $subjectIds,
+		public /* readonly */ array $statementPropertyIds,
+		public /* readonly */ int $startYear,
+		public /* readonly */ int $endYear,
+	) {
+	}
+
+}

--- a/src/Application/Export/ExportUcFactory.php
+++ b/src/Application/Export/ExportUcFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Application\Export;
+
+use ProfessionalWiki\WikibaseExport\Application\EntitySource;
+use ProfessionalWiki\WikibaseExport\Application\ExportStatementFilter;
+use ProfessionalWiki\WikibaseExport\Application\TimeQualifierProperties;
+use ProfessionalWiki\WikibaseExport\Application\TimeQualifierStatementGrouper;
+use ProfessionalWiki\WikibaseExport\Application\TimeRange;
+use ProfessionalWiki\WikibaseExport\Persistence\IdListEntitySource;
+use Wikibase\DataModel\Entity\NumericPropertyId;
+use Wikibase\Repo\WikibaseRepo;
+
+class ExportUcFactory {
+
+	public function buildUseCase(
+		ExportRequest $request,
+		ExportPresenter $presenter,
+	): ExportUseCase {
+		return new ExportUseCase(
+			entitySource: $this->newEntitySource( $request ),
+			entityMapper: $this->newEntityMapper( $request ),
+			presenter: $presenter
+		);
+	}
+
+	private function newEntitySource( ExportRequest $request ): EntitySource {
+		return new IdListEntitySource(
+			WikibaseRepo::getEntityLookup(),
+			$request->subjectIds
+		);
+	}
+
+	private function newEntityMapper( ExportRequest $request ): EntityMapper {
+		$timeQualifierProperties = $this->newTimeQualifierProperties();
+
+		return new EntityMapper(
+			statementFilter: new ExportStatementFilter(
+				propertyIds: $request->statementPropertyIds,
+				timeRange: TimeRange::newFromStartAndEndYear( $request->startYear, $request->endYear ),
+				qualifierProperties: $timeQualifierProperties
+			),
+			statementGrouper: TimeQualifierStatementGrouper::newForYearRange(
+				timeQualifierProperties: $timeQualifierProperties,
+				startYear: $request->startYear,
+				endYear: $request->endYear
+			),
+			statementMapper: new StatementMapper()
+		);
+	}
+
+	private function newTimeQualifierProperties(): TimeQualifierProperties {
+		return new TimeQualifierProperties(
+			pointInTime: new NumericPropertyId( 'P1' ), // TODO: get from config
+			startTime: new NumericPropertyId( 'P1' ), // TODO: get from config
+			endTime: new NumericPropertyId( 'P1' ), // TODO: get from config
+		);
+	}
+
+}

--- a/src/Application/TimeQualifierStatementGrouper.php
+++ b/src/Application/TimeQualifierStatementGrouper.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseExport\Application;
 
-use DateTimeImmutable;
 use Wikibase\DataModel\Statement\StatementFilter;
 use Wikibase\DataModel\Statement\StatementList;
 
@@ -44,10 +43,7 @@ class TimeQualifierStatementGrouper implements StatementGrouper {
 
 	private function newFilter( int $year ): StatementFilter {
 		return new TimeQualifierStatementFilter(
-			timeRange: new TimeRange(
-				start: new DateTimeImmutable( $year . '-01-01' ),
-				end: new DateTimeImmutable( $year . '-12-31' ),
-			),
+			timeRange: TimeRange::newFromStartAndEndYear( $year, $year ),
 			qualifierProperties: $this->timeQualifierProperties
 		);
 	}

--- a/src/Application/TimeRange.php
+++ b/src/Application/TimeRange.php
@@ -22,4 +22,13 @@ class TimeRange {
 			&& $time->getTimestamp() <= $this->end->getTimestamp();
 	}
 
+	public static function newFromStartAndEndYear( int $startYear, int $endYear ): self {
+		$endTime = new DateTimeImmutable( ( $endYear + 1 ) . '-01-01' );
+
+		return new self(
+			start: new DateTimeImmutable( $startYear . '-01-01' ),
+			end: $endTime->setTimestamp( $endTime->getTimestamp() - 1 )
+		);
+	}
+
 }

--- a/src/Persistence/IdListEntitySource.php
+++ b/src/Persistence/IdListEntitySource.php
@@ -12,12 +12,12 @@ use Wikibase\DataModel\Services\Lookup\EntityLookup;
 class IdListEntitySource implements EntitySource {
 
 	/**
-	 * @var array<int, EntityId>
+	 * @var EntityId[]
 	 */
 	private array $subjectIds;
 
 	/**
-	 * @param array<int, EntityId> $subjectIds
+	 * @param EntityId[] $subjectIds
 	 */
 	public function __construct(
 		private EntityLookup $entityLookup,

--- a/tests/Application/TimeRangeTest.php
+++ b/tests/Application/TimeRangeTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseExport\Application\TimeRange;
 
 /**
- * @covers \ProfessionalWiki\WikibaseExport\Application\TimeRangeTest
+ * @covers \ProfessionalWiki\WikibaseExport\Application\TimeRange
  */
 class TimeRangeTest extends TestCase {
 
@@ -38,6 +38,12 @@ class TimeRangeTest extends TestCase {
 				end: new DateTimeImmutable( '2005-12-31' ),
 			) )->contains( new DateTimeImmutable( '2006-01-01' ) )
 		);
+	}
+
+	public function testNewFromStartAndEndYear(): void {
+		$range = TimeRange::newFromStartAndEndYear( 2012, 2022 );
+		$this->assertSame( '2012-01-01T00:00:00+00:00', $range->start->format( 'c' ) );
+		$this->assertSame( '2022-12-31T23:59:59+00:00', $range->end->format( 'c' ) );
 	}
 
 }

--- a/tests/EntryPoints/ExportApiTest.php
+++ b/tests/EntryPoints/ExportApiTest.php
@@ -23,8 +23,8 @@ class ExportApiTest extends MediaWikiIntegrationTestCase {
 				'queryParams' => [
 					'subject_ids' => 'Q1|Q2|Q3',
 					'statement_property_ids' => 'P1|P2',
-					'start_time' => '2021',
-					'end_time' => '2022',
+					'start_year' => 2021,
+					'end_year' => 2022,
 					'format' => 'csvwide'
 				]
 			] )


### PR DESCRIPTION
Also:
* Extracted TimeRange::newFromStartAndEndYear
* API now uses start_year and end_year, instead of start_time

Fixes https://github.com/ProfessionalWiki/WikibaseExport/issues/43. Remainder tracked by https://github.com/ProfessionalWiki/WikibaseExport/issues/53