### PR TITLE
Append entity ID

### DIFF
--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -187,7 +187,7 @@ $( function () {
 		 * @return {{data: string, label: string}}
 		 */
 		getOptionFromEntity: function ( entity ) {
-			let label = entity.id;
+			let label = '';
 
 			// TODO: try specific language, then fallback
 			if ( entity.labels[ this.config.entityLabelLanguage ] !== undefined ) {
@@ -196,9 +196,11 @@ $( function () {
 				label = entity.labels.en.value;
 			}
 
+			label += ' (' + entity.id + ') ';
+
 			return {
 				data: entity.id,
-				label: label
+				label: label.trim()
 			};
 		},
 


### PR DESCRIPTION
Fixes #60
Refs #61

Quick implementation for Properties and Items. The label of the option in the dropdown is the same as what is displayed in the selected area. If we don't want that behavior then this will be somewhat more difficult, because we would need to override the widget's behavior.

If a label-less item somehow shows up (like by specifying it as a default), then it will stil have just the ID.

![Screenshot_20221119_101640](https://user-images.githubusercontent.com/1428594/202841679-6062ad51-b74f-4261-a2b6-b3ecca274819.png)
