### PR TITLE
Add JSON schema

### DIFF
--- a/example.json
+++ b/example.json
@@ -1,0 +1,19 @@
+{
+	"entityLabelLanguage": "en",
+	"chooseSubjectsLabel": "choose foo",
+	"filterSubjectsLabel": "filter foo",
+	"defaultSubjects": [
+		"Q1",
+		"Q2"
+	],
+	"defaultStartYear": 2010,
+	"defaultEndYear": 2022,
+	"startYearPropertyId": "P100",
+	"endYearPropertyId": "P200",
+	"pointInTimePropertyId": "P300",
+	"properties": [
+		"P1",
+		"P2"
+	],
+	"introText": "Lorem ipsum"
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -21,5 +21,7 @@
 	"wikibase-export-formats-heading": "Choose format",
 	"wikibase-export-format-csv-wide": "CSV (Wide)",
 	"wikibase-export-format-csv-long": "CSV (Long)",
-	"wikibase-export-download": "Download"
+	"wikibase-export-download": "Download",
+
+	"wikibase-export-config-invalid": "Your changes were not saved. It contains the following {{PLURAL:$1|error|errors}}:"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -21,5 +21,7 @@
 	"wikibase-export-formats-heading": "This is a section header.",
 	"wikibase-export-format-csv-wide": "This is the text of an option.",
 	"wikibase-export-format-csv-long": "This is the text of an option",
-	"wikibase-export-download": "This is the text on a button."
+	"wikibase-export-download": "This is the text on a button.",
+
+	"wikibase-export-config-invalid": "Error message shown when attempting to save invalid configuration on MediaWiki:WikibaseExport"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,4 +6,15 @@
       <code>$params[self::PARAM_SUBJECT_IDS]</code>
     </MixedArgument>
   </file>
+  <file src="src/Persistence/ConfigJsonValidator.php">
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>( new ErrorFormatter() )-&gt;format( $error, false )</code>
+      <code>string[]</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/Presentation/ConfigJsonErrorFormatter.php">
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$key</code>
+    </MixedArgumentTypeCoercion>
+  </file>
 </files>

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,52 @@
+{
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"entityLabelLanguage": {
+			"type": "string"
+		},
+		"chooseSubjectsLabel": {
+			"type": "string"
+		},
+		"filterSubjectsLabel": {
+			"type": "string"
+		},
+		"defaultSubjects": {
+			"type": "array",
+			"items": {
+				"type": "string",
+				"pattern": "^[qQ][1-9]\\d{0,9}$"
+			}
+		},
+		"defaultStartYear": {
+			"type": "integer"
+		},
+		"defaultEndYear": {
+			"type": "integer"
+		},
+		"startYearPropertyId": {
+			"$ref": "#/$defs/property"
+		},
+		"endYearPropertyId": {
+			"$ref": "#/$defs/property"
+		},
+		"pointInTimePropertyId": {
+			"$ref": "#/$defs/property"
+		},
+		"properties": {
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/property"
+			}
+		},
+		"introText": {
+			"type": "string"
+		}
+	},
+	"$defs": {
+		"property": {
+			"type": "string",
+			"pattern": "^[pP][1-9]\\d{0,9}$"
+		}
+	}
+}

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\WikibaseExport\EntryPoints;
 
 use EditPage;
 use ProfessionalWiki\WikibaseExport\Persistence\ConfigJsonValidator;
+use ProfessionalWiki\WikibaseExport\Presentation\ConfigJsonErrorFormatter;
 use ProfessionalWiki\WikibaseExport\WikibaseExportExtension;
 use Title;
 
@@ -24,7 +25,11 @@ class MediaWikiHooks {
 			&& WikibaseExportExtension::getInstance()->isConfigTitle( $editPage->getTitle() )
 			&& !$validator->validate( $text )
 		) {
-			$error = \Html::errorBox( wfMessage( $validator->getError() )->escaped() );
+			$errors = $validator->getErrors();
+			$error = \Html::errorBox(
+				wfMessage( 'wikibase-export-config-invalid', count( $errors ) )->escaped() .
+				ConfigJsonErrorFormatter::format( $errors )
+			);
 		}
 	}
 

--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -33,14 +33,14 @@ class ConfigDeserializer {
 			$configArray['entityLabelLanguage'] ?? null,
 			$configArray['chooseSubjectsLabel'] ?? null,
 			$configArray['filterSubjectsLabel'] ?? null,
-			$configArray['defaultSubjects'] ?? [],
+			$configArray['defaultSubjects'] ?? null,
 			$configArray['defaultStartYear'] ?? null,
 			$configArray['defaultEndYear'] ?? null,
 			$configArray['startYearPropertyId'] ?? null,
 			$configArray['endYearPropertyId'] ?? null,
 			$configArray['pointInTimePropertyId'] ?? null,
-			$configArray['properties'] ?? [],
-			$configArray['introText'] ?? '',
+			$configArray['properties'] ?? null,
+			$configArray['introText'] ?? null,
 		);
 	}
 

--- a/src/Persistence/ConfigJsonValidator.php
+++ b/src/Persistence/ConfigJsonValidator.php
@@ -4,25 +4,66 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseExport\Persistence;
 
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Errors\ValidationError;
+use Opis\JsonSchema\Validator;
+use RuntimeException;
+
 class ConfigJsonValidator {
 
+	/**
+	 * @var string[]
+	 */
+	private array $errors = [];
+
 	public static function newInstance(): self {
-		// TODO load schema
+		$json = file_get_contents( __DIR__ . '/../../schema.json' );
 
-		return new self();
+		if ( !is_string( $json ) ) {
+			throw new RuntimeException( 'Could not obtain JSON Schema' );
+		}
+
+		$schema = json_decode( $json );
+
+		if ( !is_object( $schema ) ) {
+			throw new RuntimeException( 'Failed to deserialize JSON Schema' );
+		}
+
+		return new self( $schema );
 	}
 
-	private function __construct() {
+	private function __construct(
+		private object $jsonSchema
+	) {
 	}
 
-	public function validate( string $configJson ): bool {
-		// TOOD: implement validation
-		return true;
+	public function validate( string $config ): bool {
+		$validator = new Validator();
+		$validator->setMaxErrors( 10 );
+
+		$validationResult = $validator->validate( json_decode( $config ), $this->jsonSchema );
+
+		$error = $validationResult->error();
+
+		if ( $error !== null ) {
+			$this->errors = $this->formatErrors( $error );
+		}
+
+		return $error === null;
 	}
 
-	public function getError(): string {
-		// TODO: return message string
-		return '';
+	/**
+	 * @return string[]
+	 */
+	public function getErrors(): array {
+		return $this->errors;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function formatErrors( ValidationError $error ): array {
+		return ( new ErrorFormatter() )->format( $error, false );
 	}
 
 }

--- a/src/Presentation/ConfigJsonErrorFormatter.php
+++ b/src/Presentation/ConfigJsonErrorFormatter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseExport\Presentation;
+
+class ConfigJsonErrorFormatter {
+
+	/**
+	 * @param string[] $errors
+	 */
+	public static function format( array $errors ): string {
+		$html = '<table class="wikitable">';
+
+		foreach ( $errors as $key => $value ) {
+			$html .= '<tr><td>' . htmlspecialchars( $key ) . '</td>';
+			$html .= '<td>' . htmlspecialchars( $value ) . '</td></tr>';
+		}
+
+		$html .= '</table>';
+
+		return $html;
+	}
+
+}

--- a/tests/Persistence/ConfigDeserializerTest.php
+++ b/tests/Persistence/ConfigDeserializerTest.php
@@ -5,6 +5,8 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseExport\Tests\Persistence;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseExport\Domain\Config;
+use ProfessionalWiki\WikibaseExport\Tests\TestDoubles\Valid;
 use ProfessionalWiki\WikibaseExport\WikibaseExportExtension;
 
 /**
@@ -15,7 +17,7 @@ class ConfigDeserializerTest extends TestCase {
 	public function testValidJsonReturnsConfig(): void {
 		$deserializer = WikibaseExportExtension::getInstance()->newConfigDeserializer();
 
-		$config = $deserializer->deserialize( $this->createValidConfig() );
+		$config = $deserializer->deserialize( Valid::configJson() );
 
 		$this->assertSame(
 			'en',
@@ -64,31 +66,55 @@ class ConfigDeserializerTest extends TestCase {
 	}
 
 	public function testInvalidJsonReturnsEmptyConfig(): void {
-		// TODO: implement validator
-	}
+		$deserializer = WikibaseExportExtension::getInstance()->newConfigDeserializer();
 
-	private function createValidConfig(): string {
-		return '
-{
-    "entityLabelLanguage": "en",
-    "chooseSubjectsLabel": "choose foo",
-    "filterSubjectsLabel": "filter foo",
-    "defaultSubjects": [
-        "Q1",
-        "Q2"
-    ],
-    "defaultStartYear": 2010,
-    "defaultEndYear": 2022,
-    "startYearPropertyId": "P1",
-    "endYearPropertyId": "P2",
-    "pointInTimePropertyId": "P3",
-    "properties": [
-        "P4",
-        "P5"
-    ],
-    "introText": "Lorem ipsum"
-}
-';
+		$config = $deserializer->deserialize( '}{' );
+		$emptyConfig = new Config();
+
+		$this->assertSame(
+			$emptyConfig->entityLabelLanguage,
+			$config->entityLabelLanguage
+		);
+		$this->assertSame(
+			$emptyConfig->chooseSubjectsLabel,
+			$config->chooseSubjectsLabel
+		);
+		$this->assertSame(
+			$emptyConfig->filterSubjectsLabel,
+			$config->filterSubjectsLabel
+		);
+		$this->assertSame(
+			$emptyConfig->defaultSubjects,
+			$config->defaultSubjects
+		);
+		$this->assertSame(
+			$emptyConfig->defaultStartYear,
+			$config->defaultStartYear
+		);
+		$this->assertSame(
+			$emptyConfig->defaultEndYear,
+			$config->defaultEndYear
+		);
+		$this->assertSame(
+			$emptyConfig->startYearPropertyId,
+			$config->startYearPropertyId
+		);
+		$this->assertSame(
+			$emptyConfig->endYearPropertyId,
+			$config->endYearPropertyId
+		);
+		$this->assertSame(
+			$emptyConfig->pointInTimePropertyId,
+			$config->pointInTimePropertyId
+		);
+		$this->assertSame(
+			$emptyConfig->properties,
+			$config->properties
+		);
+		$this->assertSame(
+			$emptyConfig->introText,
+			$config->introText
+		);
 	}
 
 }

--- a/tests/Persistence/ConfigJsonValidatorTest.php
+++ b/tests/Persistence/ConfigJsonValidatorTest.php
@@ -5,12 +5,41 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseExport\Tests\Persistence;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseExport\Persistence\ConfigJsonValidator;
+use ProfessionalWiki\WikibaseExport\Tests\TestDoubles\Valid;
 
 /**
  * @covers \ProfessionalWiki\WikibaseExport\Persistence\ConfigJsonValidator
  */
 class ConfigJsonValidatorTest extends TestCase {
 
-	// TODO: Implement validator
+	public function testValidJsonPassesValidation(): void {
+		$this->assertTrue(
+			ConfigJsonValidator::newInstance()->validate( Valid::configJson() )
+		);
+	}
+
+	public function testStructurallyInvalidJsonFailsValidation(): void {
+		$this->assertFalse(
+			ConfigJsonValidator::newInstance()->validate( '}{' )
+		);
+	}
+
+	public function testInvalidJsonValueFailsValidation(): void {
+		$this->assertFalse(
+			ConfigJsonValidator::newInstance()->validate( '{ "pointInTimePropertyId": "Q123abc" }' )
+		);
+	}
+
+	public function testInvalidJsonErrorsAreAvailable(): void {
+		$validator = ConfigJsonValidator::newInstance();
+
+		$validator->validate( '{ "defaultStartYear": "2022" }' );
+
+		$this->assertSame(
+			[ '/defaultStartYear' => 'The data (string) must match the type: integer' ],
+			$validator->getErrors()
+		);
+	}
 
 }

--- a/tests/Persistence/WikiConfigLookupTest.php
+++ b/tests/Persistence/WikiConfigLookupTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseExport\Tests\Persistence;
 
 use ProfessionalWiki\WikibaseExport\Domain\Config;
+use ProfessionalWiki\WikibaseExport\Tests\TestDoubles\Valid;
 use ProfessionalWiki\WikibaseExport\Tests\WikibaseExportIntegrationTest;
 use ProfessionalWiki\WikibaseExport\WikibaseExportExtension;
 
@@ -67,7 +68,7 @@ class WikiConfigLookupTest extends WikibaseExportIntegrationTest {
 	}
 
 	public function testSavedPageConfig(): void {
-		$this->editConfigPage( $this->createValidConfig() );
+		$this->editConfigPage( Valid::configJson() );
 		$lookup = WikibaseExportExtension::getInstance()->newWikiConfigLookup();
 
 		$config = $lookup->getConfig();
@@ -116,30 +117,6 @@ class WikiConfigLookupTest extends WikibaseExportIntegrationTest {
 			'Lorem ipsum',
 			$config->introText
 		);
-	}
-
-	private function createValidConfig(): string {
-		return '
-{
-    "entityLabelLanguage": "en",
-    "chooseSubjectsLabel": "choose foo",
-    "filterSubjectsLabel": "filter foo",
-    "defaultSubjects": [
-        "Q1",
-        "Q2"
-    ],
-    "defaultStartYear": 2010,
-    "defaultEndYear": 2022,
-    "startYearPropertyId": "P1",
-    "endYearPropertyId": "P2",
-    "pointInTimePropertyId": "P3",
-    "properties": [
-        "P4",
-        "P5"
-    ],
-    "introText": "Lorem ipsum"
-}
-';
 	}
 
 }

--- a/tests/TestDoubles/Valid.php
+++ b/tests/TestDoubles/Valid.php
@@ -22,4 +22,28 @@ class Valid {
 		);
 	}
 
+	public static function configJson(): string {
+		return '
+{
+    "entityLabelLanguage": "en",
+    "chooseSubjectsLabel": "choose foo",
+    "filterSubjectsLabel": "filter foo",
+    "defaultSubjects": [
+        "Q1",
+        "Q2"
+    ],
+    "defaultStartYear": 2010,
+    "defaultEndYear": 2022,
+    "startYearPropertyId": "P1",
+    "endYearPropertyId": "P2",
+    "pointInTimePropertyId": "P3",
+    "properties": [
+        "P4",
+        "P5"
+    ],
+    "introText": "Lorem ipsum"
+}
+';
+	}
+
 }


### PR DESCRIPTION
Fixes #63

I added the actual JSON validation errors to the message. I didn't spend much time on it, so if it makes it more confusing then we can remove it.

When the JSON is structurally invalid the error is a bit vague to somebody who doesn't know JSON:
![Screenshot_20221119_130813](https://user-images.githubusercontent.com/1428594/202847677-6455d9f5-f6fe-4f79-bbfc-37a54162ca55.png)
This happens for anything, like missing commas, missing quotes, extra commas, etc.

Other errors are more understandable:
![Screenshot_20221119_131103](https://user-images.githubusercontent.com/1428594/202847770-86101f61-7b21-4fce-922b-9288e616e690.png)
![Screenshot_20221119_131139](https://user-images.githubusercontent.com/1428594/202847793-ffb9647f-2320-4da8-8192-51805f6a4534.png)
