### PR TITLE
Compare objects instead of properties

### DIFF
--- a/tests/Domain/ConfigTest.php
+++ b/tests/Domain/ConfigTest.php
@@ -50,50 +50,7 @@ class ConfigTest extends TestCase {
 
 		$combined = $original->combine( $new );
 
-		$this->assertSame(
-			$original->entityLabelLanguage,
-			$combined->entityLabelLanguage
-		);
-		$this->assertSame(
-			$original->chooseSubjectsLabel,
-			$combined->chooseSubjectsLabel
-		);
-		$this->assertSame(
-			$original->filterSubjectsLabel,
-			$combined->filterSubjectsLabel
-		);
-		$this->assertSame(
-			$original->defaultSubjects,
-			$combined->defaultSubjects
-		);
-		$this->assertSame(
-			$original->defaultStartYear,
-			$combined->defaultStartYear
-		);
-		$this->assertSame(
-			$original->defaultEndYear,
-			$combined->defaultEndYear
-		);
-		$this->assertSame(
-			$original->startYearPropertyId,
-			$combined->startYearPropertyId
-		);
-		$this->assertSame(
-			$original->endYearPropertyId,
-			$combined->endYearPropertyId
-		);
-		$this->assertSame(
-			$original->pointInTimePropertyId,
-			$combined->pointInTimePropertyId
-		);
-		$this->assertSame(
-			$original->properties,
-			$combined->properties
-		);
-		$this->assertSame(
-			$original->introText,
-			$combined->introText
-		);
+		$this->assertEquals( $original, $combined );
 	}
 
 	public function testOriginalValuesAreReplacedWhenCombined(): void {
@@ -102,50 +59,7 @@ class ConfigTest extends TestCase {
 
 		$combined = $original->combine( $new );
 
-		$this->assertSame(
-			$new->entityLabelLanguage,
-			$combined->entityLabelLanguage
-		);
-		$this->assertSame(
-			$new->chooseSubjectsLabel,
-			$combined->chooseSubjectsLabel
-		);
-		$this->assertSame(
-			$new->filterSubjectsLabel,
-			$combined->filterSubjectsLabel
-		);
-		$this->assertSame(
-			$new->defaultSubjects,
-			$combined->defaultSubjects
-		);
-		$this->assertSame(
-			$new->defaultStartYear,
-			$combined->defaultStartYear
-		);
-		$this->assertSame(
-			$new->defaultEndYear,
-			$combined->defaultEndYear
-		);
-		$this->assertSame(
-			$new->startYearPropertyId,
-			$combined->startYearPropertyId
-		);
-		$this->assertSame(
-			$new->endYearPropertyId,
-			$combined->endYearPropertyId
-		);
-		$this->assertSame(
-			$new->pointInTimePropertyId,
-			$combined->pointInTimePropertyId
-		);
-		$this->assertSame(
-			$new->properties,
-			$combined->properties
-		);
-		$this->assertSame(
-			$new->introText,
-			$combined->introText
-		);
+		$this->assertEquals( $new, $combined );
 	}
 
 }

--- a/tests/Persistence/ConfigDeserializerTest.php
+++ b/tests/Persistence/ConfigDeserializerTest.php
@@ -19,49 +19,21 @@ class ConfigDeserializerTest extends TestCase {
 
 		$config = $deserializer->deserialize( Valid::configJson() );
 
-		$this->assertSame(
-			'en',
-			$config->entityLabelLanguage
-		);
-		$this->assertSame(
-			'choose foo',
-			$config->chooseSubjectsLabel
-		);
-		$this->assertSame(
-			'filter foo',
-			$config->filterSubjectsLabel
-		);
-		$this->assertSame(
-			[ 'Q1', 'Q2' ],
-			$config->defaultSubjects
-		);
-		$this->assertSame(
-			2010,
-			$config->defaultStartYear
-		);
-		$this->assertSame(
-			2022,
-			$config->defaultEndYear
-		);
-		$this->assertSame(
-			'P1',
-			$config->startYearPropertyId
-		);
-		$this->assertSame(
-			'P2',
-			$config->endYearPropertyId
-		);
-		$this->assertSame(
-			'P3',
-			$config->pointInTimePropertyId
-		);
-		$this->assertSame(
-			[ 'P4', 'P5' ],
-			$config->properties
-		);
-		$this->assertSame(
-			'Lorem ipsum',
-			$config->introText
+		$this->assertEquals(
+			new Config(
+				entityLabelLanguage: 'en',
+				chooseSubjectsLabel: 'choose foo',
+				filterSubjectsLabel: 'filter foo',
+				defaultSubjects: [ 'Q1', 'Q2' ],
+				defaultStartYear: 2010,
+				defaultEndYear: 2022,
+				startYearPropertyId: 'P1',
+				endYearPropertyId: 'P2',
+				pointInTimePropertyId: 'P3',
+				properties: [ 'P4', 'P5' ],
+				introText: 'Lorem ipsum',
+			),
+			$config
 		);
 	}
 
@@ -71,50 +43,7 @@ class ConfigDeserializerTest extends TestCase {
 		$config = $deserializer->deserialize( '}{' );
 		$emptyConfig = new Config();
 
-		$this->assertSame(
-			$emptyConfig->entityLabelLanguage,
-			$config->entityLabelLanguage
-		);
-		$this->assertSame(
-			$emptyConfig->chooseSubjectsLabel,
-			$config->chooseSubjectsLabel
-		);
-		$this->assertSame(
-			$emptyConfig->filterSubjectsLabel,
-			$config->filterSubjectsLabel
-		);
-		$this->assertSame(
-			$emptyConfig->defaultSubjects,
-			$config->defaultSubjects
-		);
-		$this->assertSame(
-			$emptyConfig->defaultStartYear,
-			$config->defaultStartYear
-		);
-		$this->assertSame(
-			$emptyConfig->defaultEndYear,
-			$config->defaultEndYear
-		);
-		$this->assertSame(
-			$emptyConfig->startYearPropertyId,
-			$config->startYearPropertyId
-		);
-		$this->assertSame(
-			$emptyConfig->endYearPropertyId,
-			$config->endYearPropertyId
-		);
-		$this->assertSame(
-			$emptyConfig->pointInTimePropertyId,
-			$config->pointInTimePropertyId
-		);
-		$this->assertSame(
-			$emptyConfig->properties,
-			$config->properties
-		);
-		$this->assertSame(
-			$emptyConfig->introText,
-			$config->introText
-		);
+		$this->assertEquals( $emptyConfig, $config );
 	}
 
 }

--- a/tests/Persistence/WikiConfigLookupTest.php
+++ b/tests/Persistence/WikiConfigLookupTest.php
@@ -21,50 +21,7 @@ class WikiConfigLookupTest extends WikibaseExportIntegrationTest {
 		$config = $lookup->getConfig();
 		$emptyConfig = new Config();
 
-		$this->assertSame(
-			$emptyConfig->entityLabelLanguage,
-			$config->entityLabelLanguage
-		);
-		$this->assertSame(
-			$emptyConfig->chooseSubjectsLabel,
-			$config->chooseSubjectsLabel
-		);
-		$this->assertSame(
-			$emptyConfig->filterSubjectsLabel,
-			$config->filterSubjectsLabel
-		);
-		$this->assertSame(
-			$emptyConfig->defaultSubjects,
-			$config->defaultSubjects
-		);
-		$this->assertSame(
-			$emptyConfig->defaultStartYear,
-			$config->defaultStartYear
-		);
-		$this->assertSame(
-			$emptyConfig->defaultEndYear,
-			$config->defaultEndYear
-		);
-		$this->assertSame(
-			$emptyConfig->startYearPropertyId,
-			$config->startYearPropertyId
-		);
-		$this->assertSame(
-			$emptyConfig->endYearPropertyId,
-			$config->endYearPropertyId
-		);
-		$this->assertSame(
-			$emptyConfig->pointInTimePropertyId,
-			$config->pointInTimePropertyId
-		);
-		$this->assertSame(
-			$emptyConfig->properties,
-			$config->properties
-		);
-		$this->assertSame(
-			$emptyConfig->introText,
-			$config->introText
-		);
+		$this->assertEquals( $emptyConfig, $config );
 	}
 
 	public function testSavedPageConfig(): void {
@@ -73,49 +30,21 @@ class WikiConfigLookupTest extends WikibaseExportIntegrationTest {
 
 		$config = $lookup->getConfig();
 
-		$this->assertSame(
-			'en',
-			$config->entityLabelLanguage
-		);
-		$this->assertSame(
-			'choose foo',
-			$config->chooseSubjectsLabel
-		);
-		$this->assertSame(
-			'filter foo',
-			$config->filterSubjectsLabel
-		);
-		$this->assertSame(
-			[ 'Q1', 'Q2' ],
-			$config->defaultSubjects
-		);
-		$this->assertSame(
-			2010,
-			$config->defaultStartYear
-		);
-		$this->assertSame(
-			2022,
-			$config->defaultEndYear
-		);
-		$this->assertSame(
-			'P1',
-			$config->startYearPropertyId
-		);
-		$this->assertSame(
-			'P2',
-			$config->endYearPropertyId
-		);
-		$this->assertSame(
-			'P3',
-			$config->pointInTimePropertyId
-		);
-		$this->assertSame(
-			[ 'P4', 'P5' ],
-			$config->properties
-		);
-		$this->assertSame(
-			'Lorem ipsum',
-			$config->introText
+		$this->assertEquals(
+			new Config(
+				entityLabelLanguage: 'en',
+				chooseSubjectsLabel: 'choose foo',
+				filterSubjectsLabel: 'filter foo',
+				defaultSubjects: [ 'Q1', 'Q2' ],
+				defaultStartYear: 2010,
+				defaultEndYear: 2022,
+				startYearPropertyId: 'P1',
+				endYearPropertyId: 'P2',
+				pointInTimePropertyId: 'P3',
+				properties: [ 'P4', 'P5' ],
+				introText: 'Lorem ipsum',
+			),
+			$config
 		);
 	}
 


### PR DESCRIPTION
Refs https://github.com/ProfessionalWiki/WikibaseExport/pull/48#discussion_r1026972304

I was overcome by extreme daftness. I was thinking about implementing an `equals()` method which would just return true/false, instead of what PHPUnit does by itself.