### PR TITLE
Add export page intro text

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -10,6 +10,7 @@
 	"special-wikibase-export": "Wikibase Export",
 	"special-wikibase-export-config": "Wikibase Export Config",
 
+	"wikibase-export-intro": "First, choose the items for which you need data. Second, choose the time range for which you need the data. Third, choose the variables you need in the CSV file. Finally, click \"$1\" to retrieve the CSV file.",
 	"wikibase-export-subjects-heading": "Choose companies",
 	"wikibase-export-subjects-placeholder": "Search companies",
 	"wikibase-export-filters-heading": "Choose time range",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -10,6 +10,7 @@
 	"special-wikibase-export": "This is the label on \"Special:WikibaseExport\".",
 	"special-wikibase-export-config": "This is the label on \"Special:WikibaseExportConfig\" linking to \"MediaWiki:WikibaseExport\".",
 
+	"wikibase-export-intro": "Text displayed at the top of \"Special:WikibaseExport\".",
 	"wikibase-export-subjects-heading": "This is a section header.",
 	"wikibase-export-subjects-placeholder": "This is the text used as a placeholder.",
 	"wikibase-export-filters-heading": "This is a section header.",

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -19,6 +19,7 @@ class SpecialWikibaseExport extends SpecialPage {
 		$output = $this->getOutput();
 		$output->enableOOUI();
 		$output->addModules( 'ext.wikibase.export' );
+		$output->addHTML( $this->getIntroText() );
 		$output->addHTML( '<div id="wikibase-export"></div>' );
 		$output->addJsConfigVars( $this->getJsConfigVars() );
 	}
@@ -29,6 +30,17 @@ class SpecialWikibaseExport extends SpecialPage {
 
 	public function getDescription(): string {
 		return $this->msg( 'special-wikibase-export' )->escaped();
+	}
+
+	private function getIntroText(): string {
+		$output = $this->getOutput();
+
+		return '<div class="container">' .
+			$output->msg(
+				'wikibase-export-intro',
+				$output->msg( 'wikibase-export-download' )->text()
+			)->text() .
+			'</div>';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #65 

![Screenshot_20221121_092238](https://user-images.githubusercontent.com/1428594/202989162-912d15b8-66a4-4eca-be07-be04d7032db7.png)

Final text should be adjusted. This is based on the original mockup.