### PR TITLE
Add JS year range validation

### DIFF
--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -11,11 +11,28 @@ $( function () {
 
 			this.$wikibaseExport = $( document.getElementById( 'wikibase-export' ) );
 
-			this.$wikibaseExport.append( this.createSubjectsSection().$element );
-			this.$wikibaseExport.append( this.createFiltersSection().$element );
-			this.$wikibaseExport.append( this.createStatementsSection().$element );
-			this.$wikibaseExport.append( this.createFormatsSection().$element );
-			this.$wikibaseExport.append( this.createActions().$element );
+			this.$wikibaseExport.append( this.createForm().$element );
+		},
+
+		/**
+		 * @return {OO.ui.FormLayout}
+		 */
+		createForm: function () {
+			this.form = new OO.ui.FormLayout( {
+				id: 'wikibase-export-form',
+				action: '',
+				method: 'get'
+			} );
+
+			this.form.addItems( [
+				this.createSubjectsSection(),
+				this.createFiltersSection(),
+				this.createStatementsSection(),
+				this.createFormatsSection(),
+				this.createActions()
+			] );
+
+			return this.form;
 		},
 
 		/**
@@ -100,14 +117,28 @@ $( function () {
 		 * @return {OO.ui.PanelLayout}
 		 */
 		createFiltersSection: function () {
+			const widget = this;
+			const yearDiff = 100;
+
 			this.startYear = new OO.ui.NumberInputWidget( {
 				id: 'startYear',
-				value: this.config.defaultStartYear
+				value: this.config.defaultStartYear,
+				required: true
 			} );
 
 			this.endYear = new OO.ui.NumberInputWidget( {
 				id: 'endYear',
-				value: this.config.defaultEndYear
+				value: this.config.defaultEndYear,
+				min: this.config.defaultStartYear,
+				max: this.config.defaultStartYear + yearDiff,
+				required: true
+			} );
+
+			this.startYear.on( 'change', function () {
+				const startYear = widget.startYear.getValue();
+				if ( widget.startYear.validate( startYear ) ) {
+					widget.endYear.setRange( startYear, parseInt( startYear ) + yearDiff );
+				}
 			} );
 
 			return this.createSection(
@@ -234,7 +265,7 @@ $( function () {
 		 * @return {OO.ui.ButtonWidget}
 		 */
 		createActions: function () {
-			const submitButton = new OO.ui.ButtonWidget( {
+			const submitButton = new OO.ui.ButtonInputWidget( {
 				id: 'download',
 				label: mw.msg( 'wikibase-export-download' ),
 				flags: [
@@ -246,7 +277,9 @@ $( function () {
 			const widget = this;
 
 			submitButton.on( 'click', function () {
-				window.location = widget.buildDownloadUrl();
+				if ( widget.form.$element[ 0 ].reportValidity() ) {
+					window.location = widget.buildDownloadUrl();
+				}
 			} );
 
 			return submitButton;


### PR DESCRIPTION
Refs #55

This changes the page to contain an actual form so that we can trigger HTML5 validation, although there is no visual change to the form itself.

The start year field is unconstrained. In the original use case it might make sense to limit both years to not be greater than the current year, but perhaps there are other use cases were future dates are allowed, so I did not implement that.

The end year limits will be changed whenever the start year value is changed. The default behavior of OOUI is to turn the field red when it is invalid (whether by changing start year or end year):
![Screenshot_20221121_164747](https://user-images.githubusercontent.com/1428594/203084357-dc2f6483-6a4b-4c1b-9473-2da213e601c1.png)

When you hover there is a tooltip:
![Screenshot_20221121_164827](https://user-images.githubusercontent.com/1428594/203084523-56d1b21d-855d-471f-a7a4-a9b0b5277183.png)

When you submit it shows the browser's HTML5 validation:
![Screenshot_20221121_164851](https://user-images.githubusercontent.com/1428594/203084616-a07d76a6-ca84-4e6f-9a66-6929cb26e73d.png)



----

Follow-ups part of #55:
* add same validation to API
* add same validation in JSON schema