### PR TITLE
Remove cache text on config page

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -35,6 +35,7 @@
 
 	"Hooks": {
 		"AlternateEdit": "ProfessionalWiki\\WikibaseExport\\EntryPoints\\MediaWikiHooks::onAlternateEdit",
+		"BeforePageDisplay": "ProfessionalWiki\\WikibaseExport\\EntryPoints\\MediaWikiHooks::onBeforePageDisplay",
 		"ContentHandlerDefaultModelFor": "ProfessionalWiki\\WikibaseExport\\EntryPoints\\MediaWikiHooks::onContentHandlerDefaultModelFor",
 		"EditFilter": "ProfessionalWiki\\WikibaseExport\\EntryPoints\\MediaWikiHooks::onEditFilter",
 		"EditFormPreloadText": "ProfessionalWiki\\WikibaseExport\\EntryPoints\\MediaWikiHooks::onEditFormPreloadText"

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseExport\EntryPoints;
 
 use EditPage;
+use OutputPage;
 use ProfessionalWiki\WikibaseExport\Persistence\ConfigJsonValidator;
 use ProfessionalWiki\WikibaseExport\Presentation\ConfigJsonErrorFormatter;
 use ProfessionalWiki\WikibaseExport\WikibaseExportExtension;
+use Skin;
 use Title;
 
 class MediaWikiHooks {
@@ -58,6 +60,30 @@ class MediaWikiHooks {
 	"introText": null
 }' );
 		}
+	}
+
+	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ): void {
+		$title = $out->getTitle();
+
+		if ( $title === null ) {
+			return;
+		}
+
+		if ( WikibaseExportExtension::getInstance()->isConfigTitle( $title ) ) {
+			$html = $out->getHTML();
+			$out->clearHTML();
+			$out->addHTML( self::getConfigPageHtml( $html ) );
+		}
+	}
+
+	private static function getConfigPageHtml( string $html ): string {
+		$jsonTablePosition = strpos( $html, '<table class="mw-json">' );
+
+		if ( !$jsonTablePosition ) {
+			return $html;
+		}
+
+		return substr( $html, $jsonTablePosition );
 	}
 
 }


### PR DESCRIPTION
Fixes #91 

![Screenshot_20221124_092042](https://user-images.githubusercontent.com/1428594/203718700-1ab5e9b3-e4c0-4b0f-ac97-94beebb56d39.png)

The [ArticleRevisionViewCustom hook](https://github.com/ProfessionalWiki/WikibaseRDF/blob/master/src/EntryPoints/MediaWikiHooks.php#L147) used in WikibaseRDF cannot be used here, because Mediawiki considers our JSON content to be special config:
![Screenshot_20221124_091712](https://user-images.githubusercontent.com/1428594/203718126-fd5c6863-6a95-4fad-8df1-728ee5e8098a.png)
![Screenshot_20221124_091731](https://user-images.githubusercontent.com/1428594/203718179-537c5e65-a99e-43a1-a5d7-fc8acbe956c5.png)
