### PR TITLE
Add separate styles resource loader

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -71,13 +71,15 @@
 	},
 
 	"ResourceModules": {
+		"ext.wikibase.export.styles": {
+			"styles": [
+				"ext.wikibase.export.less"
+			]
+		},
 		"ext.wikibase.export": {
 			"dependencies": [
 				"oojs-ui-core",
 				"oojs-ui-widgets"
-			],
-			"styles": [
-				"ext.wikibase.export.less"
 			],
 			"scripts": [
 				"mw.widgets.EntitiesMultiselectWidget.js",

--- a/resources/ext.wikibase.export.js
+++ b/resources/ext.wikibase.export.js
@@ -54,10 +54,7 @@ $( function () {
 				expanded: false,
 				framed: true,
 				padded: true,
-				$content: fieldset.$element,
-				classes: [
-					'container'
-				]
+				$content: fieldset.$element
 			} );
 		},
 

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -18,9 +18,10 @@ class SpecialWikibaseExport extends SpecialPage {
 		parent::execute( $subPage );
 		$output = $this->getOutput();
 		$output->enableOOUI();
+		$output->addModuleStyles( 'ext.wikibase.export.styles' );
 		$output->addModules( 'ext.wikibase.export' );
 		$output->addHTML( $this->getIntroText() );
-		$output->addHTML( '<div id="wikibase-export"></div>' );
+		$output->addHTML( '<div id="wikibase-export" class="container"></div>' );
 		$output->addJsConfigVars( $this->getJsConfigVars() );
 	}
 

--- a/tests/EntryPoints/SpecialWikibaseExportTest.php
+++ b/tests/EntryPoints/SpecialWikibaseExportTest.php
@@ -21,7 +21,7 @@ class SpecialWikibaseExportTest extends SpecialPageTestBase {
 		[ $output ] = $this->executeSpecialPage();
 
 		$this->assertStringContainsString(
-			'<div id="wikibase-export"></div>',
+			'<div id="wikibase-export" class="container"></div>',
 			$output
 		);
 	}


### PR DESCRIPTION
This separates the CSS from the JS resource loader. When they are combined it has to wait for everything before it gets the CSS. This causes the `container` class to load late, which makes the intro paragraph take up full width for a moment:
![Screenshot_20221126_115644](https://user-images.githubusercontent.com/1428594/204082923-61736a05-8b56-43b1-9d46-5a112e483399.png)
