### PR TITLE
Improve widget pending and request handling

### DIFF
--- a/resources/mw.widgets.EntitiesMultiselectWidget.js
+++ b/resources/mw.widgets.EntitiesMultiselectWidget.js
@@ -5,8 +5,6 @@
 	 *
 	 * @class
 	 * @extends OO.ui.MenuTagMultiselectWidget
-	 * @mixins OO.ui.mixin.RequestManager
-	 * @mixins OO.ui.mixin.PendingElement
 	 *
 	 * @constructor
 	 * @param {Object} [config] Configuration options
@@ -97,11 +95,11 @@
 	 * @inheritdoc OO.ui.mixin.RequestManager
 	 */
 	mw.widgets.EntitiesMultiselectWidget.prototype.getRequest = function () {
-		var promiseAbortObject = { abort: function () {
-				// Do nothing. This is just so OOUI doesn't break due to abort being undefined.
-			} };
+		const promiseAbortObject = { abort: function () {
+			// Do nothing. This is just so OOUI doesn't break due to abort being undefined.
+		} };
 
-		var req = new mw.Api().get( {
+		const req = new mw.Api().get( {
 			action: 'wbsearchentities',
 			type: this.entityType,
 			language: this.language,


### PR DESCRIPTION
Trying to see if #84 might be caused by the parts I stripped out of MW's `TitlesMultiselectWidget`. The issue still persists, unless I missed something important that i stripped out. Either way, this PR adds some improvements.

When querying it shows a "pending" animation. It's hard to screenshot, but basically the grey area at the top gets moving diagonal stripes.

This also improves request handling by aborting old requests while the user types and also adds caching for search terms.