### PR TITLE
Add incomplete config warning

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,6 +25,7 @@
 	"wikibase-export-download": "Download",
 
 	"wikibase-export-config-invalid": "Your changes were not saved. It contains the following {{PLURAL:$1|error|errors}}:",
+	"wikibase-export-config-incomplete": "Some configuration is incomplete and the export will not work.",
 
 	"wikibase-export-config-help": "Configuration documentation",
 	"wikibase-export-config-help-variables": "Variables:",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -25,6 +25,7 @@
 	"wikibase-export-download": "This is the text on a button.",
 
 	"wikibase-export-config-invalid": "Error message shown when attempting to save invalid configuration on MediaWiki:WikibaseExport",
+	"wikibase-export-config-incomplete": "Error message shown on \"Special:WikibaseExport\" when required configuration is incomplete.",
 
 	"wikibase-export-config-help": "Help text heading displayed on \"MediaWiki:WikibaseExport\"",
 	"wikibase-export-config-help-variables": "Help text heading displayed on \"MediaWiki:WikibaseExport\"",

--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseExport\Application;
 
+use Exception;
 use RuntimeException;
 
 class Config {
@@ -57,6 +58,17 @@ class Config {
 		}
 
 		return $this->pointInTimePropertyId;
+	}
+
+	public function isComplete(): bool {
+		try {
+			$this->getStartTimePropertyId();
+			$this->getEndTimePropertyId();
+			$this->getPointInTimePropertyId();
+			return true;
+		} catch ( Exception ) {
+			return false;
+		}
 	}
 
 }

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseExport\EntryPoints;
 
+use Html;
 use ProfessionalWiki\WikibaseExport\Application\Config;
 use ProfessionalWiki\WikibaseExport\WikibaseExportExtension;
 use SpecialPage;
@@ -19,10 +20,17 @@ class SpecialWikibaseExport extends SpecialPage {
 		$output = $this->getOutput();
 		$output->enableOOUI();
 		$output->addModuleStyles( 'ext.wikibase.export.styles' );
-		$output->addModules( 'ext.wikibase.export' );
-		$output->addHTML( $this->getIntroText() );
-		$output->addHTML( '<div id="wikibase-export" class="container"></div>' );
-		$output->addJsConfigVars( $this->getJsConfigVars() );
+		$output->addHTML( '<div id="wikibase-export" class="container">' );
+
+		if ( $this->configIsComplete() ) {
+			$output->addModules( 'ext.wikibase.export' );
+			$output->addHTML( $this->getIntroText() );
+			$output->addJsConfigVars( $this->getJsConfigVars() );
+		} else {
+			$output->addHTML( $this->getConfigIncompleteWarning() );
+		}
+
+		$output->addHTML( '</div>' );
 	}
 
 	public function getGroupName(): string {
@@ -33,15 +41,21 @@ class SpecialWikibaseExport extends SpecialPage {
 		return $this->msg( 'special-wikibase-export' )->escaped();
 	}
 
+	private function configIsComplete(): bool {
+		return WikibaseExportExtension::getInstance()->newConfigLookup()->getConfig()->isComplete();
+	}
+
+	private function getConfigIncompleteWarning(): string {
+		return Html::errorBox( $this->msg( 'wikibase-export-config-incomplete' )->parse() );
+	}
+
 	private function getIntroText(): string {
 		$output = $this->getOutput();
 
-		return '<div class="container">' .
-			$output->msg(
-				'wikibase-export-intro',
-				$output->msg( 'wikibase-export-download' )->text()
-			)->text() .
-			'</div>';
+		return $output->msg(
+			'wikibase-export-intro',
+			$output->msg( 'wikibase-export-download' )->text()
+		)->text();
 	}
 
 	/**

--- a/tests/EntryPoints/SpecialWikibaseExportTest.php
+++ b/tests/EntryPoints/SpecialWikibaseExportTest.php
@@ -21,7 +21,7 @@ class SpecialWikibaseExportTest extends SpecialPageTestBase {
 		[ $output ] = $this->executeSpecialPage();
 
 		$this->assertStringContainsString(
-			'<div id="wikibase-export" class="container"></div>',
+			'<div id="wikibase-export" class="container">',
 			$output
 		);
 	}


### PR DESCRIPTION
Fixes #68

This is a quick implementation showing a message and hiding the form:
![Screenshot_20221128_074719](https://user-images.githubusercontent.com/1428594/204203165-26dd736f-ce57-42db-a3fc-16e7e2d2e76f.png)

The message should be tweaked. Perhaps link to the config page?

This is to prevent an ugly exception if the user tries to export:
![Screenshot_20221128_072808](https://user-images.githubusercontent.com/1428594/204200805-e1a49962-c7d6-4163-a59a-3d3173f1ecb0.png)

The use case here is if LocalSettings is misconfigured and there is no in-wiki config. Since we discard invalid LocalSettings config without any warning, the user might not be aware that something is wrong/missing.