### PR TITLE
Add top help section on config edit page

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -26,6 +26,7 @@
 
 	"wikibase-export-config-invalid": "Your changes were not saved. It contains the following {{PLURAL:$1|error|errors}}:",
 
+	"wikibase-export-config-help-documentation": "View configuration documentation",
 	"wikibase-export-config-help": "Configuration documentation",
 	"wikibase-export-config-help-variables": "Variables:",
 	"wikibase-export-config-help-example": "Full example:",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -26,6 +26,7 @@
 
 	"wikibase-export-config-invalid": "Error message shown when attempting to save invalid configuration on MediaWiki:WikibaseExport",
 
+	"wikibase-export-config-help-documentation": "Link to documentation displayed on \"MediaWiki:WikibaseExport\"",
 	"wikibase-export-config-help": "Help text heading displayed on \"MediaWiki:WikibaseExport\"",
 	"wikibase-export-config-help-variables": "Help text heading displayed on \"MediaWiki:WikibaseExport\"",
 	"wikibase-export-config-help-example": "Help text heading displayed on \"MediaWiki:WikibaseExport\"",

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -43,7 +43,8 @@ class MediaWikiHooks {
 			$editPage->suppressIntro = true;
 
 			$textBuilder = new ExportConfigEditPageTextBuilder( $editPage->getContext() );
-			$editPage->editFormTextBottom = $textBuilder->createHtml();
+			$editPage->editFormTextTop = $textBuilder->createTopHtml();
+			$editPage->editFormTextBottom = $textBuilder->createBottomHtml();
 		}
 	}
 

--- a/src/Presentation/ExportConfigEditPageTextBuilder.php
+++ b/src/Presentation/ExportConfigEditPageTextBuilder.php
@@ -15,13 +15,25 @@ class ExportConfigEditPageTextBuilder {
 	) {
 	}
 
-	public function createHtml(): string {
-		return '<div class="wikibase-export-config-help">' .
+	public function createTopHtml(): string {
+		return '<div id="wikibase-export-config-help-top">' .
+			$this->createMessagesSection() .
+			$this->createDocumentationLink() .
+			'</div>';
+	}
+
+	public function createBottomHtml(): string {
+		return '<div id="wikibase-export-config-help-bottom">' .
 			'<h2>' . $this->context->msg( 'wikibase-export-config-help' )->escaped() . '</h2>' .
 			$this->creatVariablesSection() .
 			$this->createExampleSection() .
-			$this->createMessagesSection() .
 			'</div>';
+	}
+
+	private function createDocumentationLink(): string {
+		return '<p><a href="#wikibase-export-config-help-bottom">' .
+			$this->context->msg( 'wikibase-export-config-help-documentation' )->escaped() .
+			'</a></p>';
 	}
 
 	private function creatVariablesSection(): string {
@@ -81,7 +93,7 @@ class ExportConfigEditPageTextBuilder {
 	}
 
 	private function createMessagesSection(): string {
-		return '<h3>' . $this->context->msg( 'wikibase-export-config-help-messages' )->escaped() . '</h3>' .
+		return '<p>' . $this->context->msg( 'wikibase-export-config-help-messages' )->escaped() . '</p>' .
 			'<ul>' .
 			$this->createMessageLinkItem(
 				'wikibase-export-intro',


### PR DESCRIPTION
Moves message list to the top.
Adds link to the docs section at the bottom.

![image](https://user-images.githubusercontent.com/1428594/204263188-26e29c4f-1a9b-4089-bc37-008847ebb077.png)
