### PR TITLE
Add conditional config link

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,7 +25,8 @@
 	"wikibase-export-download": "Download",
 
 	"wikibase-export-config-invalid": "Your changes were not saved. It contains the following {{PLURAL:$1|error|errors}}:",
-	"wikibase-export-config-incomplete": "Wikibase Export needs to be configured by an administrator before it can be used. [[Special:WikibaseExportConfig|Configure now]]",
+	"wikibase-export-config-incomplete": "Wikibase Export needs to be configured by an administrator before it can be used.",
+	"wikibase-export-config-incomplete-link": "You can [[Special:WikibaseExportConfig|configure this form]].",
 
 	"wikibase-export-config-help-documentation": "View configuration documentation",
 	"wikibase-export-config-help": "Configuration documentation",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -26,6 +26,7 @@
 
 	"wikibase-export-config-invalid": "Error message shown when attempting to save invalid configuration on MediaWiki:WikibaseExport",
 	"wikibase-export-config-incomplete": "Error message shown on \"Special:WikibaseExport\" when required configuration is incomplete.",
+	"wikibase-export-config-incomplete-link": "Config page link shown on \"Special:WikibaseExport\" when required configuration is incomplete.",
 
 	"wikibase-export-config-help-documentation": "Link to documentation displayed on \"MediaWiki:WikibaseExport\"",
 	"wikibase-export-config-help": "Help text heading displayed on \"MediaWiki:WikibaseExport\"",

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseExport\EntryPoints;
 
 use Html;
+use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\WikibaseExport\Application\Config;
 use ProfessionalWiki\WikibaseExport\WikibaseExportExtension;
 use SpecialPage;
@@ -49,7 +50,18 @@ class SpecialWikibaseExport extends SpecialPage {
 	}
 
 	private function getConfigIncompleteWarning(): string {
-		return Html::errorBox( $this->msg( 'wikibase-export-config-incomplete' )->parse() );
+		$text = $this->msg( 'wikibase-export-config-incomplete' )->parse();
+
+		if ( $this->shouldShowConfigLink() ) {
+			$text .= '<br/>' . $this->msg( 'wikibase-export-config-incomplete-link' )->parse();
+		}
+
+		return Html::errorBox( $text );
+	}
+
+	private function shouldShowConfigLink(): bool {
+		return MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseExportEnableInWikiConfig' ) === true
+			&& $this->getUser()->isAllowed( 'editinterface' );
 	}
 
 	private function getIntroText(): string {


### PR DESCRIPTION
Fixes #124 

When in-wiki config is disallowed or if the user cannot edit system messages:
![Screenshot_20221130_102948](https://user-images.githubusercontent.com/1428594/204746040-37eaf6f2-b8dd-41cc-aab0-13bffeb8de91.png)

Otherwise:
![Screenshot_20221130_103140](https://user-images.githubusercontent.com/1428594/204746272-276bda81-eba2-4857-8365-e96887764751.png)
