### PR TITLE
Add subject filter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,17 @@ Caution: invalid JSON will be ignored. No error will be shown, the intended conf
 
 #### JSON Variables
 
-| Variable                | Description                                                                  | Example          |
-|-------------------------|------------------------------------------------------------------------------|------------------|
-| `startTimePropertyId`   | Property ID of the qualifier used for the start of a time range.             | `P100`           |
-| `endTimePropertyId`     | Property ID of the qualifier used for the end of a time range.               | `P200`           |
-| `pointInTimePropertyId` | Property ID of the qualifier used for a specific point in time.              | `P300`           |
-| `properties`            | List of IDs of properties for statements that may be included in the export. | `[ "P1", "P2" ]` |
-| `defaultSubjects`       | List of IDs of items that should be selected by default.                     | `[ "Q1", "Q2" ]` |
-| `defaultStartYear`      | The default start year.                                                      | `2010`           |
-| `defaultEndYear`        | The default end year.                                                        | `2022`           |
+| Variable                     | Description                                                                           | Example          |
+|------------------------------|---------------------------------------------------------------------------------------|------------------|
+| `startTimePropertyId`        | Property ID of the qualifier used for the start of a time range.                      | `P100`           |
+| `endTimePropertyId`          | Property ID of the qualifier used for the end of a time range.                        | `P200`           |
+| `pointInTimePropertyId`      | Property ID of the qualifier used for a specific point in time.                       | `P300`           |
+| `properties`                 | List of IDs of properties for statements that may be included in the export.          | `[ "P1", "P2" ]` |
+| `defaultSubjects`            | List of IDs of items that should be selected by default.                              | `[ "Q1", "Q2" ]` |
+| `defaultStartYear`           | The default start year.                                                               | `2010`           |
+| `defaultEndYear`             | The default end year.                                                                 | `2022`           |
+| `subjectFilterPropertyId`    | Property ID of the statement used to filter items that may be included in the export. | `P50`            |
+| `subjectFilterPropertyValue` | Expected value of the subject filter property.                                        | `company`        |
 
 The following variables are required and must be defined in either [LocalSettings.php] or using the in-wiki configuration page:
 * `startTimePropertyId`

--- a/example.json
+++ b/example.json
@@ -11,5 +11,7 @@
 		"Q2"
 	],
 	"defaultStartYear": 2010,
-	"defaultEndYear": 2022
+	"defaultEndYear": 2022,
+	"subjectFilterPropertyId": "P50",
+	"subjectFilterPropertyValue": "company"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -48,5 +48,7 @@
 	"wikibase-export-config-help-variable-start-time-property-id": "Property ID of the qualifier used for the start of a time range.",
 	"wikibase-export-config-help-variable-end-time-property-id": "Property ID of the qualifier used for the end of a time range.",
 	"wikibase-export-config-help-variable-point-in-time-property-id": "Property ID of the qualifier used for a specific point in time.",
-	"wikibase-export-config-help-variable-properties": "List of IDs of properties for statements that may be included in the export."
+	"wikibase-export-config-help-variable-properties": "List of IDs of properties for statements that may be included in the export.",
+	"wikibase-export-config-help-variable-subject-filter-property-id": "Property ID of the statement used to filter items that may be included in the export.",
+	"wikibase-export-config-help-variable-subject-filter-property-value": "Expected value of the subject filter property."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -48,5 +48,7 @@
 	"wikibase-export-config-help-variable-start-time-property-id": "Help text displayed on \"MediaWiki:WikibaseExport\"",
 	"wikibase-export-config-help-variable-end-time-property-id": "Help text displayed on \"MediaWiki:WikibaseExport\"",
 	"wikibase-export-config-help-variable-point-in-time-property-id": "Help text displayed on \"MediaWiki:WikibaseExport\"",
-	"wikibase-export-config-help-variable-properties": "Help text displayed on \"MediaWiki:WikibaseExport\""
+	"wikibase-export-config-help-variable-properties": "Help text displayed on \"MediaWiki:WikibaseExport\"",
+	"wikibase-export-config-help-variable-subject-filter-property-id": "Help text displayed on \"MediaWiki:WikibaseExport\"",
+	"wikibase-export-config-help-variable-subject-filter-property-value": "Help text displayed on \"MediaWiki:WikibaseExport\""
 }

--- a/schema.json
+++ b/schema.json
@@ -29,6 +29,12 @@
 			"items": {
 				"$ref": "#/$defs/property"
 			}
+		},
+		"subjectFilterPropertyId": {
+			"$ref": "#/$defs/property"
+		},
+		"subjectFilterPropertyValue": {
+			"type": [ "string", "null" ]
 		}
 	},
 	"dependentSchemas": {

--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -20,7 +20,9 @@ class Config {
 		public /* readonly */ ?string $startTimePropertyId = null,
 		public /* readonly */ ?string $endTimePropertyId = null,
 		public /* readonly */ ?string $pointInTimePropertyId = null,
-		public /* readonly */ ?array $properties = null
+		public /* readonly */ ?array $properties = null,
+		public /* readonly */ ?string $subjectFilterPropertyId = null,
+		public /* readonly */ ?string $subjectFilterPropertyValue = null
 	) {
 	}
 
@@ -32,7 +34,9 @@ class Config {
 			$config->startTimePropertyId ?? $this->startTimePropertyId,
 			$config->endTimePropertyId ?? $this->endTimePropertyId,
 			$config->pointInTimePropertyId ?? $this->pointInTimePropertyId,
-			$config->properties ?? $this->properties
+			$config->properties ?? $this->properties,
+			$config->subjectFilterPropertyId ?? $this->subjectFilterPropertyId,
+			$config->subjectFilterPropertyValue ?? $this->subjectFilterPropertyValue
 		);
 	}
 

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -60,7 +60,9 @@ class MediaWikiHooks {
 	"defaultSubjects": [
 	],
 	"defaultStartYear": null,
-	"defaultEndYear": null
+	"defaultEndYear": null,
+	"subjectFilterPropertyId": null,
+	"subjectFilterPropertyValue": null
 }' );
 		}
 	}

--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -36,7 +36,9 @@ class ConfigDeserializer {
 			$configArray['startTimePropertyId'] ?? null,
 			$configArray['endTimePropertyId'] ?? null,
 			$configArray['pointInTimePropertyId'] ?? null,
-			$configArray['properties'] ?? null
+			$configArray['properties'] ?? null,
+			$configArray['subjectFilterPropertyId'] ?? null,
+			$configArray['subjectFilterPropertyValue'] ?? null
 		);
 	}
 

--- a/src/Presentation/ExportConfigEditPageTextBuilder.php
+++ b/src/Presentation/ExportConfigEditPageTextBuilder.php
@@ -88,6 +88,18 @@ class ExportConfigEditPageTextBuilder {
 				'2022',
 				false
 			) .
+			$this->createTableRow(
+				'subjectFilterPropertyId',
+				'wikibase-export-config-help-variable-subject-filter-property-id',
+				'"P50"',
+				false
+			) .
+			$this->createTableRow(
+				'subjectFilterPropertyValue',
+				'wikibase-export-config-help-variable-subject-filter-property-value',
+				'"company"',
+				false
+			) .
 			'</tbody>' .
 			'</table>';
 	}

--- a/tests/Application/ConfigTest.php
+++ b/tests/Application/ConfigTest.php
@@ -20,7 +20,9 @@ class ConfigTest extends TestCase {
 			startTimePropertyId: 'P1',
 			endTimePropertyId: 'P2',
 			pointInTimePropertyId: 'P3',
-			properties: [ 'P10', 'P11' ]
+			properties: [ 'P10', 'P11' ],
+			subjectFilterPropertyId: 'P15',
+			subjectFilterPropertyValue: 'company'
 		);
 	}
 
@@ -32,7 +34,9 @@ class ConfigTest extends TestCase {
 			startTimePropertyId: 'P4',
 			endTimePropertyId: 'P5',
 			pointInTimePropertyId: 'P6',
-			properties: [ 'P20', 'P21' ]
+			properties: [ 'P20', 'P21' ],
+			subjectFilterPropertyId: 'P25',
+			subjectFilterPropertyValue: 'organization'
 		);
 	}
 

--- a/tests/Persistence/ConfigDeserializerTest.php
+++ b/tests/Persistence/ConfigDeserializerTest.php
@@ -27,7 +27,9 @@ class ConfigDeserializerTest extends TestCase {
 				startTimePropertyId: 'P1',
 				endTimePropertyId: 'P2',
 				pointInTimePropertyId: 'P3',
-				properties: [ 'P4', 'P5' ]
+				properties: [ 'P4', 'P5' ],
+				subjectFilterPropertyId: 'P10',
+				subjectFilterPropertyValue: 'company'
 			),
 			$config
 		);

--- a/tests/Persistence/PageContentConfigLookupTest.php
+++ b/tests/Persistence/PageContentConfigLookupTest.php
@@ -39,7 +39,9 @@ class PageContentConfigLookupTest extends WikibaseExportIntegrationTest {
 				startTimePropertyId: 'P1',
 				endTimePropertyId: 'P2',
 				pointInTimePropertyId: 'P3',
-				properties: [ 'P4', 'P5' ]
+				properties: [ 'P4', 'P5' ],
+				subjectFilterPropertyId: 'P10',
+				subjectFilterPropertyValue: 'company'
 			),
 			$config
 		);

--- a/tests/TestDoubles/Valid.php
+++ b/tests/TestDoubles/Valid.php
@@ -37,7 +37,9 @@ class Valid {
     "properties": [
         "P4",
         "P5"
-    ]
+    ],
+	"subjectFilterPropertyId": "P10",
+	"subjectFilterPropertyValue": "company"
 }
 ';
 	}


### PR DESCRIPTION
Config-only part of #29, irrespective of whether we implement the actual filtering in PHP or JS. Doing this as a standalone PR so that the entire implementation is not dumped at once.

Since the extension is not release yet it should be fine to refer to this (currently) unimplemented feature in the docs.