### PR TITLE
Always show admin config message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,6 +11,7 @@
 	"special-wikibase-export-config": "Wikibase Export Config",
 
 	"wikibase-export-intro": "First, choose the items for which you need data. Second, choose the time range for which you need the data. Third, choose the variables you need in the CSV file. Finally, click \"$1\" to retrieve the CSV file.",
+	"wikibase-export-intro-admin-notice": "As an administrator, you can [[Special:WikibaseExportConfig|configure this form]].",
 	"wikibase-export-subjects-heading": "Subjects to export",
 	"wikibase-export-subjects-placeholder": "Search subjects (items)",
 	"wikibase-export-grouped-statements-heading": "Values grouped by year",
@@ -22,7 +23,7 @@
 	"wikibase-export-download": "Download",
 
 	"wikibase-export-config-invalid": "Your changes were not saved. It contains the following {{PLURAL:$1|error|errors}}:",
-	"wikibase-export-config-incomplete": "Wikibase Export needs to be configured by an administrator before it can be used.",
+	"wikibase-export-config-incomplete": "An administrator needs to configure Wikibase Export before it can be used.",
 	"wikibase-export-config-incomplete-link": "You can [[Special:WikibaseExportConfig|configure this form]].",
 
 	"wikibase-export-config-help-documentation": "View configuration documentation",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -11,6 +11,7 @@
 	"special-wikibase-export-config": "This is the label on \"Special:WikibaseExportConfig\" linking to \"MediaWiki:WikibaseExport\".",
 
 	"wikibase-export-intro": "Text displayed at the top of \"Special:WikibaseExport\".",
+	"wikibase-export-intro-admin-notice": "Text displayed at the top of \"Special:WikibaseExport\" to users with the interface-admin right.",
 	"wikibase-export-subjects-heading": "This is a section header.",
 	"wikibase-export-subjects-placeholder": "This is the text used as a placeholder.",
 	"wikibase-export-grouped-statements-heading": "This is a section header.",

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -48,12 +48,18 @@ class SpecialWikibaseExport extends SpecialPage {
 	}
 
 	private function getIntroText(): string {
-		$output = $this->getOutput();
+		$intro = '<p>'
+			. $this->msg(
+				'wikibase-export-intro',
+				$this->msg( 'wikibase-export-download' )->text()
+			)->text()
+			. '</p>';
 
-		return $output->msg(
-			'wikibase-export-intro',
-			$output->msg( 'wikibase-export-download' )->text()
-		)->text();
+		if ( $this->shouldShowConfigLink() ) {
+			$intro .= '<p>' . $this->msg( 'wikibase-export-intro-admin-notice' )->parse() . '</p>';
+		}
+
+		return $intro;
 	}
 
 	/**


### PR DESCRIPTION
Added a link to the top that always shows for admins.

![image](https://user-images.githubusercontent.com/146040/206863952-620b42d0-2298-475c-8b15-a77547737b0f.png)
