### PR TITLE
Fix null property ID exception

### DIFF
--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -49,7 +49,7 @@ class ConfigDeserializer {
 	}
 
 	private function propertyIdOrNull( array $configArray, string $configKey ): ?PropertyId {
-		if ( array_key_exists( $configKey, $configArray ) ) {
+		if ( array_key_exists( $configKey, $configArray ) && $configArray[$configKey] !== null ) {
 			return new NumericPropertyId( $configArray[$configKey] );
 		}
 

--- a/tests/Persistence/ConfigDeserializerTest.php
+++ b/tests/Persistence/ConfigDeserializerTest.php
@@ -53,4 +53,13 @@ class ConfigDeserializerTest extends TestCase {
 		$this->assertEquals( $emptyConfig, $config );
 	}
 
+	public function testNullPropertyIdReturnsNull(): void {
+		$deserializer = WikibaseExportExtension::getInstance()->newConfigDeserializer();
+
+		$config = $deserializer->deserialize( '{ "startTimePropertyId": null }' );
+		$emptyConfig = new Config();
+
+		$this->assertEquals( $emptyConfig, $config );
+	}
+
 }


### PR DESCRIPTION
When saving default/unchanged config using the in-wiki page:
![Screenshot_20221213_162822](https://user-images.githubusercontent.com/1428594/207359951-15b9ca85-b3c5-4417-9903-ff0fbda9ad7a.png)

Then the `null` property IDs throw an exception on the export page:
![Screenshot_20221213_162914](https://user-images.githubusercontent.com/1428594/207360160-18488fc3-6582-42de-8dd1-ab77539b9b9c.png)

This fixes it with an explicit null check.