### PR TITLE
Add test database annotation

### DIFF
--- a/tests/Application/Export/ProductionValueSetCreatorTest.php
+++ b/tests/Application/Export/ProductionValueSetCreatorTest.php
@@ -28,6 +28,7 @@ use Wikibase\DataModel\Statement\StatementList;
 
 /**
  * @covers \ProfessionalWiki\WikibaseExport\Application\Export\ProductionValueSetCreator
+ * @group Database
  */
 class ProductionValueSetCreatorTest extends MediaWikiIntegrationTestCase {
 

--- a/tests/EntryPoints/SpecialWikibaseExportTest.php
+++ b/tests/EntryPoints/SpecialWikibaseExportTest.php
@@ -9,6 +9,7 @@ use SpecialPageTestBase;
 
 /**
  * @covers \ProfessionalWiki\WikibaseExport\EntryPoints\SpecialWikibaseExport
+ * @group Database
  */
 class SpecialWikibaseExportTest extends SpecialPageTestBase {
 

--- a/tests/Presentation/ConfigPageSmokeTest.php
+++ b/tests/Presentation/ConfigPageSmokeTest.php
@@ -6,6 +6,9 @@ namespace ProfessionalWiki\WikibaseExport\Tests\Presentation;
 
 use ProfessionalWiki\WikibaseExport\Tests\WikibaseExportIntegrationTest;
 
+/**
+ * @group Database
+ */
 class ConfigPageSmokeTest extends WikibaseExportIntegrationTest {
 
 	public function testSmoke(): void {


### PR DESCRIPTION
Solves a few "RuntimeException: Database backend disabled" errors on MW 1.43.