### PR TITLE
Optimize onEditFilter

### DIFF
--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -22,12 +22,13 @@ class MediaWikiHooks {
 	}
 
 	public static function onEditFilter( EditPage $editPage, ?string $text, ?string $section, string &$error ): void {
+		if ( !is_string( $text ) || !WikibaseExportExtension::getInstance()->isConfigTitle( $editPage->getTitle() ) ) {
+			return;
+		}
+
 		$validator = ConfigJsonValidator::newInstance();
 
-		if ( is_string( $text )
-			&& WikibaseExportExtension::getInstance()->isConfigTitle( $editPage->getTitle() )
-			&& !$validator->validate( $text )
-		) {
+		if ( !$validator->validate( $text ) ) {
 			$errors = $validator->getErrors();
 			$error = \Html::errorBox(
 				wfMessage( 'wikibase-export-config-invalid', count( $errors ) )->escaped() .


### PR DESCRIPTION
Before it always called ConfigJsonValidator::newInstance(), which reads a JSON file from disk. With a guard clause it is more efficient and more readable.

Same as https://github.com/ProfessionalWiki/WikibaseFacetedSearch/pull/74