### PR TITLE
Add fallback getDescription method for MW < 1.41 compat

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,3 +19,13 @@ parameters:
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: src/WikibaseExportExtension.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: src/EntryPoints/SpecialWikibaseExport.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: src/EntryPoints/SpecialWikibaseExportConfig.php

--- a/src/EntryPoints/SpecialWikibaseExport.php
+++ b/src/EntryPoints/SpecialWikibaseExport.php
@@ -38,8 +38,15 @@ class SpecialWikibaseExport extends SpecialPage {
 		return 'wikibase';
 	}
 
-	public function getDescription(): Message {
-		return $this->msg( 'special-wikibase-export' );
+	/**
+	 * @return string|Message Returns string in MW < 1.41 and Message in MW >= 1.41
+	 */
+	public function getDescription() {
+		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
+			return $this->msg( 'special-wikibase-export' );
+		} else {
+			return $this->msg( 'special-wikibase-export' )->escaped();
+		}
 	}
 
 	private function shouldShowConfigLink(): bool {

--- a/src/EntryPoints/SpecialWikibaseExportConfig.php
+++ b/src/EntryPoints/SpecialWikibaseExportConfig.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseExport\EntryPoints;
 
+use Message;
 use SpecialPage;
 use Title;
 
@@ -27,8 +28,15 @@ class SpecialWikibaseExportConfig extends SpecialPage {
 		return 'wikibase';
 	}
 
-	public function getDescription(): string {
-		return $this->msg( 'special-wikibase-export-config' )->escaped();
+	/**
+	 * @return string|Message Returns string in MW < 1.41 and Message in MW >= 1.41
+	 */
+	public function getDescription() {
+		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
+			return $this->msg( 'special-wikibase-export-config' );
+		} else {
+			return $this->msg( 'special-wikibase-export-config' )->escaped();
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes: #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with different MediaWiki versions for export-related descriptions, ensuring correct display across versions 1.41 and above as well as earlier versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->